### PR TITLE
Add backend for user preferences with validation

### DIFF
--- a/src/backend/src/controllers/PreferencesController.js
+++ b/src/backend/src/controllers/PreferencesController.js
@@ -1,0 +1,82 @@
+import Preferences from "../models/Preferences.js";
+
+export const getPreferences = async (req, res) => {
+    try {
+        const preferences = await Preferences.findOne({ userId: req.query.userId });
+        if (!preferences) {
+            return res.status(404).json({ message: "Preferences not found" });
+        }
+        res.json(preferences);
+    } catch (err) {
+        res.status(500).json({ message: "Server error" });
+    }
+};
+
+const validateOtherField = (other) => {
+    if (!other || other.trim() === "") {
+        return true;
+    }
+    const regex = /^[a-zA-Z\s]+$/;
+    return regex.test(other.trim());
+};
+
+export const createPreferences = async (req, res) => {
+    try {
+        const { userId, dietaryRestrictions, allergies, otherAllergy } = req.body;
+        if (!validateOtherField(otherAllergy)) {
+            return res.status(400).json({ message: "Invalid input in 'otherAllergy' field" });
+        }
+
+        let trimmedOtherAllergy = "";
+        if (otherAllergy) {
+            trimmedOtherAllergy = otherAllergy.trim();
+        }
+
+        const newPreferences = new Preferences({
+            userId,
+            dietaryRestrictions,
+            allergies,
+            otherAllergy: trimmedOtherAllergy,
+        });
+        await newPreferences.save();
+        res.status(201).json(newPreferences);
+    } catch (err) {
+        res.status(500).json({ message: "Server error" });
+    }
+};
+
+export const updatePreferences = async (req, res) => {
+    try {
+        const { userId, dietaryRestrictions, allergies, otherAllergy } = req.body;
+        if (!validateOtherField(otherAllergy)) {
+            return res.status(400).json({ message: "Invalid input in 'otherAllergy' field" });
+        }
+
+        let trimmedOtherAllergy = "";
+        if (otherAllergy) {
+            trimmedOtherAllergy = otherAllergy.trim();
+        }
+
+        const updatedPreferences = await Preferences.findOneAndUpdate(
+            { userId },
+            { 
+                dietaryRestrictions, 
+                allergies, 
+                otherAllergy: trimmedOtherAllergy 
+            },
+            { new: true }
+        );
+        res.json({message: "Preferences updated", preferences: updatedPreferences});
+    } catch (err) {
+        res.status(500).json({ message: "Server error" });
+    }
+};
+
+export const deletePreferences = async (req, res) => {
+    try {
+        await Preferences.findOneAndDelete({ userId: req.query.userId });
+        res.json({ message: "Preferences deleted" });
+    } catch (err) {
+        res.status(500).json({ message: "Server error" });
+    }
+};

--- a/src/backend/src/index.js
+++ b/src/backend/src/index.js
@@ -4,7 +4,7 @@ import dotenv from "dotenv";
 import cors from "cors";
 import helmet from "helmet";
 import authRoutes from "./routes/authRoutes.js";
-
+import preferencesRoutes from "./routes/preferencesRoutes.js";
 dotenv.config();
 
 const app = express();
@@ -14,6 +14,7 @@ const PORT = process.env.PORT || 5000;
 app.use(cors());
 app.use(helmet());
 app.use(express.json());
+app.use("/api/preferences", preferencesRoutes);
 
 // Connect to MongoDB
 connectDB();

--- a/src/backend/src/models/Preferences.js
+++ b/src/backend/src/models/Preferences.js
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose';
+
+const preferenceSchema = new mongoose.Schema({
+    userId: {
+        type: String,
+        required: true,
+    },
+    dietaryRestrictions: {
+        type: [String],
+        default: [],
+    },
+    allergies: {
+        type: [String],
+        default: [],
+    },
+    otherAllergy: {
+        type: String,
+        default: "",
+    },
+});
+
+export default mongoose.model('Preference', preferenceSchema);

--- a/src/backend/src/routes/preferencesRoutes.js
+++ b/src/backend/src/routes/preferencesRoutes.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import {
+    getPreferences,
+    createPreferences,
+    updatePreferences,
+    deletePreferences,
+} from '../controllers/PreferencesController.js';
+
+const router = express.Router();
+
+router.get('/', getPreferences);
+router.post('/', createPreferences);
+router.put('/', updatePreferences);
+router.delete('/', deletePreferences);
+
+export default router;


### PR DESCRIPTION
Closes #12 
 
This PR aims to implement the backend for the user preferences page. 

Added validation for the "Other" field in allergies (letters and spaces only, no special characters)

Added database storing for user preferences as well as fetching through API endpoints: 
- GET /api/preferences?userId=<userId>
- POST /api/preferences
- PUT /api/preferences
- DELETE /api/preferences?userId=<userId>

Tested the API operations with Postman to make sure everything worked. 


This PR creates the need to handle the invalid inputs for the "Other" field by displaying a message to the user on the frontend if we get a "400" status code. An issue for this new feature has been created [here](https://github.com/tarakanner/MealMajor-SOEN341_Project_W26/issues/30) to keep track of it. 