### PR TITLE
Add backend APIs for weekly meal plans

### DIFF
--- a/src/backend/src/controllers/WeeklyMealPlanController.js
+++ b/src/backend/src/controllers/WeeklyMealPlanController.js
@@ -1,0 +1,95 @@
+import WeeklyMealPlan from "../models/WeeklyMealPlan.js";
+
+const VALID_DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+const VALID_MEAL_TYPES = ["breakfast", "lunch", "dinner", "snack"];
+
+export const getMealPlan = async (req, res) => {
+    try {
+        const { userId } = req.query;
+
+        if (!userId) {
+            return res.status(400).json({ message: "userId is required" });
+        }
+
+        const mealPlan = await WeeklyMealPlan.findOne({ userId }).populate("meals.recipeId");
+
+        if (!mealPlan) {
+            return res.status(404).json({ message: "Meal plan not found" });
+        }
+
+        res.json(mealPlan);
+    } catch (err) {
+        res.status(500).json({ message: "Server error" });
+    }
+};
+
+export const addOrUpdateMeal = async (req, res) => {
+    try {
+        const { userId, day, mealType, recipeId } = req.body;
+
+        if (!userId || !day || !mealType || !recipeId) {
+            return res.status(400).json({ message: "Missing required fields" });
+        }
+
+        if (!VALID_DAYS.includes(day)) {
+            return res.status(400).json({ message: "Invalid day" });
+        }
+
+        if (!VALID_MEAL_TYPES.includes(mealType)) {
+            return res.status(400).json({ message: "Invalid meal type" });
+        }
+
+        let mealPlan = await WeeklyMealPlan.findOne({ userId });
+
+        if (!mealPlan) {
+            mealPlan = new WeeklyMealPlan({ userId, meals: [{ day, mealType, recipeId }] });
+            await mealPlan.save();
+            return res.status(201).json(mealPlan);
+        }
+
+        const existingMeal = mealPlan.meals.find(
+            (m) => m.day === day && m.mealType === mealType
+        );
+
+        if (existingMeal) {
+            existingMeal.recipeId = recipeId;
+        } else {
+            mealPlan.meals.push({ day, mealType, recipeId });
+        }
+
+        await mealPlan.save();
+        res.json(mealPlan);
+    } catch (err) {
+        res.status(500).json({ message: "Server error" });
+    }
+};
+
+export const deleteMeal = async (req, res) => {
+    try {
+        const { mealId } = req.params;
+        const { userId } = req.query;
+
+        if (!userId) {
+            return res.status(400).json({ message: "userId is required" });
+        }
+
+        const mealPlan = await WeeklyMealPlan.findOne({ userId });
+
+        if (!mealPlan) {
+            return res.status(404).json({ message: "Meal plan not found" });
+        }
+
+        const mealExists = mealPlan.meals.id(mealId);
+
+        if (!mealExists) {
+            return res.status(404).json({ message: "Meal not found" });
+        }
+
+        mealPlan.meals.pull({ _id: mealId });
+        await mealPlan.save();
+
+        res.json({ message: "Meal deleted successfully" });
+    } catch (err) {
+        res.status(500).json({ message: "Server error" });
+    }
+};

--- a/src/backend/src/index.js
+++ b/src/backend/src/index.js
@@ -6,6 +6,7 @@ import helmet from "helmet";
 import authRoutes from "./routes/authRoutes.js";
 import preferencesRoutes from "./routes/preferencesRoutes.js";
 import recipeRoutes from "./routes/recipeRoutes.js";
+import weeklyMealPlanRoutes from "./routes/weeklyMealPlanRoutes.js";
 dotenv.config();
 
 const app = express();
@@ -22,6 +23,7 @@ connectDB();
 app.use("/api/auth", authRoutes);
 app.use("/api/preferences", preferencesRoutes);
 app.use("/api/recipes", recipeRoutes);
+app.use("/api/meal-plan", weeklyMealPlanRoutes);
 
 // Start server
 app.listen(PORT, () => {

--- a/src/backend/src/routes/weeklyMealPlanRoutes.js
+++ b/src/backend/src/routes/weeklyMealPlanRoutes.js
@@ -1,0 +1,10 @@
+import express from "express";
+import { getMealPlan, addOrUpdateMeal, deleteMeal } from "../controllers/WeeklyMealPlanController.js";
+
+const router = express.Router();
+
+router.get("/", getMealPlan);
+router.post("/", addOrUpdateMeal);
+router.delete("/:mealId", deleteMeal);
+
+export default router;


### PR DESCRIPTION
closes #89 

Added API endpoints for the weekly meal plans

## GET /api/meal-plan
takes required `userId`
## POST /api/meal-plan
takes json body: 
```
{
  "userId": "string",
  "day": "Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday",
  "mealType": "breakfast|lunch|dinner|snack",
  "recipeId": "string"
}
```
If a meal already exists for the same day+mealType, it updates the recipe; otherwise adds a new meal


## DELETE /api/meal-plan/:mealId
takes `mealId `and `userId`

<hr>

###  Tested all possible requests/errors with Postman (all passed successfully). 
<br>